### PR TITLE
Fix parse errors for huge and empty nodes

### DIFF
--- a/enex2notion/enex_parser_xml.py
+++ b/enex2notion/enex_parser_xml.py
@@ -27,6 +27,7 @@ def iter_process_xml_elements(
             recover=True,
             strip_cdata=False,
             resolve_entities=False,
+            huge_tree=True,
         )
 
         try:

--- a/enex2notion/note_parser/note.py
+++ b/enex2notion/note_parser/note.py
@@ -48,13 +48,14 @@ def _parse_note_dom(note: EvernoteNote) -> Optional[Tag]:
 
 
 def _filter_yinxiang_markdown(note_dom: Tag) -> Tag:
-    last_block = note_dom.contents[-1]
+    if len(note_dom.contents) > 0:
+        last_block = note_dom.contents[-1]
 
-    if not isinstance(last_block, Tag):
-        return note_dom
+        if not isinstance(last_block, Tag):
+            return note_dom
 
-    if "display:none" in last_block.attrs.get("style", ""):
-        last_block.extract()
+        if "display:none" in last_block.attrs.get("style", ""):
+            last_block.extract()
 
     return note_dom
 

--- a/enex2notion/note_parser/note.py
+++ b/enex2notion/note_parser/note.py
@@ -44,18 +44,20 @@ def _parse_note_dom(note: EvernoteNote) -> Optional[Tag]:
         logger.error(f"Failed to extract DOM from note '{note.title}'")
         return None
 
+    if len(note_dom.contents) == 0:
+        return None
+
     return _filter_yinxiang_markdown(note_dom)
 
 
 def _filter_yinxiang_markdown(note_dom: Tag) -> Tag:
-    if len(note_dom.contents) > 0:
-        last_block = note_dom.contents[-1]
+    last_block = note_dom.contents[-1]
 
-        if not isinstance(last_block, Tag):
-            return note_dom
+    if not isinstance(last_block, Tag):
+        return note_dom
 
-        if "display:none" in last_block.attrs.get("style", ""):
-            last_block.extract()
+    if "display:none" in last_block.attrs.get("style", ""):
+        last_block.extract()
 
     return note_dom
 

--- a/tests/test_note_parser.py
+++ b/tests/test_note_parser.py
@@ -654,6 +654,22 @@ def test_linebreaks_inside_root(parse_html):
     ]
 
 
+def test_empty_note(parse_rules):
+    test_note = EvernoteNote(
+        title="test1",
+        created=datetime(2021, 11, 18, 0, 0, 0, tzinfo=tzutc()),
+        updated=datetime(2021, 11, 18, 0, 0, 0, tzinfo=tzutc()),
+        content="<en-note></en-note>",
+        tags=[],
+        author="",
+        url="",
+        is_webclip=False,
+        resources=[],
+    )
+
+    assert parse_note(test_note, parse_rules) == []
+
+
 def test_yinxiang_markdown(parse_rules):
     test_note = EvernoteNote(
         title="test1",


### PR DESCRIPTION
- Enabled the "huge_tree" option in the XML parser to prevent the "xmlSAX2Characters: huge text node" error.
- Fixed a "list index out of range" error that happened on some notes with title but no content.

Fixes #101.