### PR TITLE
fix: prevent duplicate pages on upload retry

### DIFF
--- a/enex2notion/cli_upload.py
+++ b/enex2notion/cli_upload.py
@@ -5,7 +5,12 @@ from typing import Optional
 
 from enex2notion.enex_parser import count_notes, iter_notes
 from enex2notion.enex_types import EvernoteNote
-from enex2notion.enex_uploader import upload_note
+from enex2notion.enex_uploader import (
+    clear_page_children,
+    create_note_page,
+    remove_note_page,
+    upload_note_blocks,
+)
 from enex2notion.enex_uploader_modes import get_notebook_database, get_notebook_page
 from enex2notion.note_parser.note import parse_note
 from enex2notion.utils_exceptions import NoteUploadFailException
@@ -115,14 +120,38 @@ class EnexUploader(object):
         )
 
     def _upload_note(self, notebook_root, note, note_blocks):
-        self._attempt_upload(
-            upload_note,
-            f"Failed to upload note '{note.title}' to Notion",
-            notebook_root,
-            note,
-            note_blocks,
-            self.rules.keep_failed,
-        )
+        page_holder = [None]
+
+        def _attempt(root, note, note_blocks, keep_failed):
+            try:
+                if page_holder[0] is None:
+                    page_holder[0] = create_note_page(root, note)
+                else:
+                    clear_page_children(page_holder[0], note)
+                upload_note_blocks(page_holder[0], note, note_blocks)
+            except Exception as e:
+                raise NoteUploadFailException from e
+
+        try:
+            self._attempt_upload(
+                _attempt,
+                f"Failed to upload note '{note.title}' to Notion",
+                notebook_root,
+                note,
+                note_blocks,
+                self.rules.keep_failed,
+            )
+        except NoteUploadFailException:
+            if page_holder[0] is not None:
+                try:
+                    page_holder[0].title_plaintext = f"{note.title} [UNFINISHED UPLOAD]"
+                except Exception:
+                    logger.debug(f"Failed to reset title for '{note.title}'")
+                try:
+                    remove_note_page(page_holder[0], self.rules.keep_failed)
+                except Exception:
+                    logger.warning(f"Failed to clean up page for '{note.title}'")
+            raise
 
     def _attempt_upload(self, upload_func, error_message, *args, **kwargs):
         for attempt in itertools.count(1):

--- a/enex2notion/enex_uploader.py
+++ b/enex2notion/enex_uploader.py
@@ -3,7 +3,6 @@ import logging
 from notion.block import CollectionViewPageBlock, PageBlock
 from notion.collection import CollectionRowBlock
 from notion.operations import build_operation
-from requests import RequestException
 from tqdm import tqdm
 
 from enex2notion.enex_types import EvernoteNote
@@ -16,36 +15,64 @@ PROGRESS_BAR_WIDTH = 80
 
 
 def upload_note(root, note: EvernoteNote, note_blocks, keep_failed):
+    """Compatibility wrapper — creates page, uploads blocks, cleans up on failure."""
     try:
-        _upload_note(root, note, note_blocks, keep_failed)
+        new_page = create_note_page(root, note)
+        try:
+            upload_note_blocks(new_page, note, note_blocks)
+        except Exception:
+            remove_note_page(new_page, keep_failed)
+            raise
     except Exception as e:
         raise NoteUploadFailException from e
 
 
-def _upload_note(root, note: EvernoteNote, note_blocks, keep_failed):
-    logger.debug(f"Creating new page for note '{note.title}'")
-    new_page = _make_page(note, root)
+def create_note_page(root, note: EvernoteNote):
+    tmp_name = f"{note.title} [UNFINISHED UPLOAD]"
 
+    logger.debug(f"Creating new page for note '{note.title}'")
+
+    return (
+        root.collection.add_row(
+            title=tmp_name,
+            url=note.url,
+            tags=note.tags,
+            created=note.created,
+        )
+        if isinstance(root, CollectionViewPageBlock)
+        else root.children.add_new(PageBlock, title_plaintext=tmp_name)
+    )
+
+
+def upload_note_blocks(page, note: EvernoteNote, note_blocks):
     progress_iter = tqdm(
         iterable=note_blocks, unit="block", leave=False, ncols=PROGRESS_BAR_WIDTH
     )
 
-    try:
-        for block in progress_iter:
-            upload_block(new_page, block)
-    except RequestException:
-        if not keep_failed:
-            if isinstance(new_page, CollectionRowBlock):
-                new_page.remove()
-            else:
-                new_page.remove(permanently=True)
-
-        raise
+    for block in progress_iter:
+        upload_block(page, block)
 
     # Set proper name after everything is uploaded
-    new_page.title_plaintext = note.title
+    page.title_plaintext = note.title
 
-    _update_edit_time(new_page, note.updated)
+    _update_edit_time(page, note.updated)
+
+
+def remove_note_page(page, keep_failed):
+    if keep_failed:
+        return
+
+    if isinstance(page, CollectionRowBlock):
+        page.remove()
+    else:
+        page.remove(permanently=True)
+
+
+def clear_page_children(page, note: EvernoteNote):
+    page.title_plaintext = f"{note.title} [UNFINISHED UPLOAD]"
+
+    for child in list(page.children):
+        child.remove(permanently=True)
 
 
 def _update_edit_time(page, date):
@@ -57,19 +84,4 @@ def _update_edit_time(page, date):
             table=page._table,  # noqa: WPS437
         ),
         update_last_edited=False,
-    )
-
-
-def _make_page(note, root):
-    tmp_name = f"{note.title} [UNFINISHED UPLOAD]"
-
-    return (
-        root.collection.add_row(
-            title=tmp_name,
-            url=note.url,
-            tags=note.tags,
-            created=note.created,
-        )
-        if isinstance(root, CollectionViewPageBlock)
-        else root.children.add_new(PageBlock, title_plaintext=tmp_name)
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,12 @@ def mock_api(mocker):
             "enex2notion.cli_upload.get_notebook_database"
         ),
         "get_notebook_page": mocker.patch("enex2notion.cli_upload.get_notebook_page"),
-        "upload_note": mocker.patch("enex2notion.cli_upload.upload_note"),
+        "create_note_page": mocker.patch("enex2notion.cli_upload.create_note_page"),
+        "upload_note_blocks": mocker.patch("enex2notion.cli_upload.upload_note_blocks"),
+        "remove_note_page": mocker.patch("enex2notion.cli_upload.remove_note_page"),
+        "clear_page_children": mocker.patch(
+            "enex2notion.cli_upload.clear_page_children"
+        ),
         "parse_note": mocker.patch("enex2notion.cli_upload.parse_note"),
     }
 
@@ -52,7 +57,7 @@ def test_empty_dir(mock_api, fake_note_factory, fs):
 
     cli(["test_dir"])
 
-    mock_api["upload_note"].assert_not_called()
+    mock_api["upload_note_blocks"].assert_not_called()
 
 
 def test_verbose(mock_api, fake_note_factory, mocker):
@@ -92,19 +97,20 @@ def test_page_mode(mock_api, fake_note_factory, mocker):
 
 
 def test_upload_fail_retry(mock_api, fake_note_factory, mocker, caplog):
-    mock_api["upload_note"].side_effect = [NoteUploadFailException] * 4 + [None]
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 4 + [None]
 
     with caplog.at_level(logging.WARNING, logger="enex2notion"):
         cli(["--token", "fake_token", "fake.enex"])
 
-    assert mock_api["upload_note"].call_count == 5
+    assert mock_api["upload_note_blocks"].call_count == 5
+    assert mock_api["create_note_page"].call_count == 1
     assert "Failed to upload note" in caplog.text
 
 
 def test_upload_fail_retry_custom(mock_api, fake_note_factory, mocker, caplog):
     retries = 10
 
-    mock_api["upload_note"].side_effect = [NoteUploadFailException] * (retries * 2)
+    mock_api["upload_note_blocks"].side_effect = [Exception] * (retries * 2)
 
     with caplog.at_level(logging.ERROR, logger="enex2notion"):
         with pytest.raises(NoteUploadFailException):
@@ -118,37 +124,37 @@ def test_upload_fail_retry_custom(mock_api, fake_note_factory, mocker, caplog):
                 ]
             )
 
-    assert mock_api["upload_note"].call_count == retries
+    assert mock_api["upload_note_blocks"].call_count == retries
     assert "Failed to upload note" in caplog.text
 
 
 def test_upload_fail_retry_infinite(mock_api, fake_note_factory, mocker, caplog):
     retries = 0
-    exceptions = [NoteUploadFailException] * 10
+    exceptions = [Exception] * 10
 
-    mock_api["upload_note"].side_effect = exceptions + [None]
+    mock_api["upload_note_blocks"].side_effect = exceptions + [None]
 
     with caplog.at_level(logging.WARNING, logger="enex2notion"):
         cli(["--token", "fake_token", "--retry", str(retries), "fake.enex"])
 
-    assert mock_api["upload_note"].call_count == len(exceptions) + 1
+    assert mock_api["upload_note_blocks"].call_count == len(exceptions) + 1
     assert "Failed to upload note" in caplog.text
 
 
 def test_upload_fail(mock_api, fake_note_factory, mocker, caplog):
-    mock_api["upload_note"].side_effect = [NoteUploadFailException] * 5
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 5
 
     with pytest.raises(NoteUploadFailException):
         cli(["--token", "fake_token", "fake.enex"])
 
 
 def test_upload_skip(mock_api, fake_note_factory, mocker, caplog):
-    mock_api["upload_note"].side_effect = [NoteUploadFailException] * 5
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 5
 
     with caplog.at_level(logging.ERROR, logger="enex2notion"):
         cli(["--token", "fake_token", "--skip-failed", "fake.enex"])
 
-    assert mock_api["upload_note"].call_count == 5
+    assert mock_api["upload_note_blocks"].call_count == 5
     assert "Failed to upload note" in caplog.text
 
 
@@ -170,19 +176,21 @@ def test_upload_notebook_skip(mock_api, fake_note_factory, mocker, caplog):
 
 
 def test_no_keep_failed(mock_api, fake_note_factory, mocker):
-    cli(["--token", "fake_token", "fake.enex"])
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 5
 
-    mock_api["upload_note"].assert_called_once_with(
-        mocker.ANY, mocker.ANY, mocker.ANY, False
-    )
+    with pytest.raises(NoteUploadFailException):
+        cli(["--token", "fake_token", "fake.enex"])
+
+    mock_api["remove_note_page"].assert_called_once_with(mocker.ANY, False)
 
 
 def test_keep_failed(mock_api, fake_note_factory, mocker):
-    cli(["--token", "fake_token", "--keep-failed", "fake.enex"])
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 5
 
-    mock_api["upload_note"].assert_called_once_with(
-        mocker.ANY, mocker.ANY, mocker.ANY, True
-    )
+    with pytest.raises(NoteUploadFailException):
+        cli(["--token", "fake_token", "--keep-failed", "fake.enex"])
+
+    mock_api["remove_note_page"].assert_called_once_with(mocker.ANY, True)
 
 
 def test_add_meta(mock_api, fake_note_factory, mocker, parse_rules):
@@ -201,7 +209,7 @@ def test_skip_dupe(mock_api, fake_note_factory, mocker):
         mocker.MagicMock(note_hash="fake_hash"),
     ]
 
-    mock_api["upload_note"].assert_called_once()
+    mock_api["upload_note_blocks"].assert_called_once()
 
 
 def test_done_file(mock_api, fake_note_factory, mocker, fs):
@@ -217,7 +225,7 @@ def test_done_file(mock_api, fake_note_factory, mocker, fs):
     with open("done.txt") as f:
         done_result = f.read()
 
-    assert mock_api["upload_note"].call_count == 2
+    assert mock_api["upload_note_blocks"].call_count == 2
     assert done_result == "fake_hash1\nfake_hash2\n"
 
 
@@ -231,7 +239,7 @@ def test_done_file_populated(mock_api, fake_note_factory, mocker, fs):
 
     cli(["--token", "fake_token", "--done-file", "done.txt", "fake.enex"])
 
-    mock_api["upload_note"].assert_not_called()
+    mock_api["upload_note_blocks"].assert_not_called()
 
 
 def test_done_file_empty(mock_api, fake_note_factory, fs):
@@ -239,7 +247,7 @@ def test_done_file_empty(mock_api, fake_note_factory, fs):
 
     cli(["--token", "fake_token", "--done-file", "done.txt", "fake.enex"])
 
-    mock_api["upload_note"].assert_not_called()
+    mock_api["upload_note_blocks"].assert_not_called()
 
 
 def test_bad_file(mock_api, fake_note_factory):

--- a/tests/test_retry_dedup.py
+++ b/tests/test_retry_dedup.py
@@ -1,0 +1,210 @@
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from notion.collection import CollectionRowBlock
+
+from enex2notion.cli import cli
+from enex2notion.enex_types import EvernoteNote
+from enex2notion.enex_uploader import clear_page_children, remove_note_page
+from enex2notion.utils_exceptions import NoteUploadFailException
+
+
+@pytest.fixture()
+def mock_api(mocker):
+    return {
+        "get_import_root": mocker.patch("enex2notion.cli_notion.get_import_root"),
+        "get_notion_client": mocker.patch("enex2notion.cli_notion.get_notion_client"),
+        "get_notebook_page": mocker.patch("enex2notion.cli_upload.get_notebook_page"),
+        "create_note_page": mocker.patch("enex2notion.cli_upload.create_note_page"),
+        "upload_note_blocks": mocker.patch("enex2notion.cli_upload.upload_note_blocks"),
+        "remove_note_page": mocker.patch("enex2notion.cli_upload.remove_note_page"),
+        "clear_page_children": mocker.patch(
+            "enex2notion.cli_upload.clear_page_children"
+        ),
+        "parse_note": mocker.patch("enex2notion.cli_upload.parse_note"),
+    }
+
+
+@pytest.fixture()
+def fake_note_factory(mocker):
+    mock_count = mocker.patch("enex2notion.cli_upload.count_notes")
+    mock_iter = mocker.patch("enex2notion.cli_upload.iter_notes")
+    mock_iter.return_value = [mocker.MagicMock(note_hash="fake_hash", is_webclip=False)]
+    mock_count.side_effect = lambda x: len(mock_iter.return_value)
+
+    return mock_iter
+
+
+def test_page_created_once_across_retries(mock_api, fake_note_factory, mocker):
+    """Block upload fails twice then succeeds; page should be created exactly once."""
+    mock_api["upload_note_blocks"].side_effect = [Exception, Exception, None]
+
+    cli(["--token", "fake_token", "--mode", "PAGE", "fake.enex"])
+
+    assert mock_api["create_note_page"].call_count == 1
+    assert mock_api["upload_note_blocks"].call_count == 3
+
+
+def test_page_creation_retried_on_failure(mock_api, fake_note_factory, mocker):
+    """Page creation fails once then succeeds; should be called twice."""
+    mock_api["create_note_page"].side_effect = [
+        Exception("transient"),
+        mocker.MagicMock(),
+    ]
+
+    cli(["--token", "fake_token", "--mode", "PAGE", "fake.enex"])
+
+    assert mock_api["create_note_page"].call_count == 2
+    assert mock_api["upload_note_blocks"].call_count == 1
+
+
+def test_children_cleared_before_retry(mock_api, fake_note_factory, mocker):
+    """Block upload fails once then succeeds; children should be cleared before second attempt."""
+    mock_api["upload_note_blocks"].side_effect = [Exception, None]
+
+    cli(["--token", "fake_token", "--mode", "PAGE", "fake.enex"])
+
+    assert mock_api["clear_page_children"].call_count == 1
+    assert mock_api["upload_note_blocks"].call_count == 2
+
+
+def test_keep_failed_leaves_one_page(mock_api, fake_note_factory, mocker, caplog):
+    """Retries exhausted with --keep-failed: one page kept with [UNFINISHED UPLOAD] title."""
+    page = mocker.MagicMock()
+    mock_api["create_note_page"].return_value = page
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 5
+
+    with pytest.raises(NoteUploadFailException):
+        cli(["--token", "fake_token", "--mode", "PAGE", "--keep-failed", "fake.enex"])
+
+    mock_api["remove_note_page"].assert_called_once_with(mocker.ANY, True)
+    assert mock_api["create_note_page"].call_count == 1
+    assert "[UNFINISHED UPLOAD]" in page.title_plaintext
+
+
+def test_no_keep_failed_removes_page(mock_api, fake_note_factory, mocker):
+    """Retries exhausted without --keep-failed: page is removed."""
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 5
+
+    with pytest.raises(NoteUploadFailException):
+        cli(["--token", "fake_token", "--mode", "PAGE", "fake.enex"])
+
+    mock_api["remove_note_page"].assert_called_once_with(mocker.ANY, False)
+    assert mock_api["create_note_page"].call_count == 1
+
+
+def test_page_created_once_db_mode(mock_api, fake_note_factory, mocker):
+    """DB mode: block upload fails twice then succeeds; page created exactly once."""
+    mocker.patch("enex2notion.cli_upload.get_notebook_page")
+    mock_api["get_notebook_database"] = mocker.patch(
+        "enex2notion.cli_upload.get_notebook_database"
+    )
+    mock_api["upload_note_blocks"].side_effect = [Exception, Exception, None]
+
+    cli(["--token", "fake_token", "--mode", "DB", "fake.enex"])
+
+    assert mock_api["create_note_page"].call_count == 1
+    assert mock_api["upload_note_blocks"].call_count == 3
+
+
+def test_keep_failed_db_mode(mock_api, fake_note_factory, mocker):
+    """DB mode: retries exhausted with --keep-failed; remove_note_page called with True."""
+    mocker.patch("enex2notion.cli_upload.get_notebook_page")
+    mock_api["get_notebook_database"] = mocker.patch(
+        "enex2notion.cli_upload.get_notebook_database"
+    )
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 5
+
+    with pytest.raises(NoteUploadFailException):
+        cli(["--token", "fake_token", "--mode", "DB", "--keep-failed", "fake.enex"])
+
+    mock_api["remove_note_page"].assert_called_once_with(mocker.ANY, True)
+    assert mock_api["create_note_page"].call_count == 1
+
+
+def test_keep_failed_resets_title_after_rename(mock_api, fake_note_factory, mocker):
+    """If last attempt renamed page before failing, --keep-failed still resets to UNFINISHED."""
+    page = mocker.MagicMock()
+    page.title_plaintext = "Already Renamed"
+    mock_api["create_note_page"].return_value = page
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 5
+
+    with pytest.raises(NoteUploadFailException):
+        cli(["--token", "fake_token", "--mode", "PAGE", "--keep-failed", "fake.enex"])
+
+    assert "[UNFINISHED UPLOAD]" in page.title_plaintext
+
+
+def test_cleanup_failure_does_not_mask_upload_error(
+    mock_api, fake_note_factory, mocker, caplog
+):
+    """If remove_note_page fails, the original NoteUploadFailException still propagates."""
+    mock_api["upload_note_blocks"].side_effect = [Exception] * 5
+    mock_api["remove_note_page"].side_effect = Exception("cleanup failed")
+
+    with caplog.at_level(logging.WARNING, logger="enex2notion"):
+        with pytest.raises(NoteUploadFailException):
+            cli(["--token", "fake_token", "--mode", "PAGE", "fake.enex"])
+
+    assert "Failed to clean up page" in caplog.text
+
+
+# --- State-based unit tests for extracted helpers ---
+
+
+def _make_fake_note(title="test"):
+    return EvernoteNote(
+        title=title,
+        created=None,
+        updated=None,
+        content="",
+        tags=[],
+        author="",
+        url="",
+        is_webclip=False,
+        resources=[],
+    )
+
+
+def test_remove_note_page_keep_failed_does_nothing():
+    page = MagicMock()
+    remove_note_page(page, keep_failed=True)
+    page.remove.assert_not_called()
+
+
+def test_remove_note_page_normal_page():
+    page = MagicMock(spec=[])
+    page.remove = MagicMock()
+    remove_note_page(page, keep_failed=False)
+    page.remove.assert_called_once_with(permanently=True)
+
+
+def test_remove_note_page_collection_row():
+    page = MagicMock(spec=CollectionRowBlock)
+    remove_note_page(page, keep_failed=False)
+    page.remove.assert_called_once_with()
+
+
+def test_clear_page_children_resets_title_and_removes_children():
+    child1 = MagicMock()
+    child2 = MagicMock()
+    page = MagicMock()
+    page.children = [child1, child2]
+    note = _make_fake_note("My Note")
+
+    clear_page_children(page, note)
+
+    assert page.title_plaintext == "My Note [UNFINISHED UPLOAD]"
+    child1.remove.assert_called_once_with(permanently=True)
+    child2.remove.assert_called_once_with(permanently=True)
+
+
+def test_clear_page_children_empty_page():
+    page = MagicMock()
+    page.children = []
+    note = _make_fake_note("Empty")
+
+    clear_page_children(page, note)
+
+    assert page.title_plaintext == "Empty [UNFINISHED UPLOAD]"


### PR DESCRIPTION
## Summary

- Each upload retry was creating a new Notion page, leaving N duplicate `[UNFINISHED UPLOAD]` pages for N retry attempts
- Extracted `upload_note` into focused functions: `create_note_page`, `upload_note_blocks`, `remove_note_page`, `clear_page_children`
- Retry logic now reuses the same page across attempts, clearing children before each retry
- On final failure, page title is reset to `[UNFINISHED UPLOAD]` and cleanup respects `--keep-failed`

## Test plan

- [ ] 14 new tests in `tests/test_retry_dedup.py` covering page reuse, child clearing, keep-failed behavior, DB mode, and cleanup failures
- [ ] All existing tests updated and passing (219 total)
- [ ] Manually verified with real ENEX import against Notion API