### PR TITLE
fix: handle Notion attachment URL format in file upload

### DIFF
--- a/enex2notion/enex_uploader_block.py
+++ b/enex2notion/enex_uploader_block.py
@@ -60,15 +60,19 @@ def _upload_file(new_block, resource: EvernoteResource):
 
 
 def _extract_file_id(url):
-    # aws_host/space_id/file_id/filename
+    # New format: attachment:file_id:filename
+    attachment_re = r"^attachment:([a-f0-9\-]+):(.+)$"
+    attachment_match = re.search(attachment_re, url)
+    if attachment_match:
+        return attachment_match.group(1)
+
+    # Old format: aws_host/space_id/file_id/filename
     aws_re = r"^https://(.*?\.amazonaws\.com)/([a-f0-9\-]+)/([a-f0-9\-]+)/(.*?)$"
-
     aws_match = re.search(aws_re, url)
+    if aws_match:
+        return aws_match.group(3)
 
-    if not aws_match:
-        raise ValueError(f"Uploaded file URL format changed: {url}")
-
-    return aws_match.group(3)
+    raise ValueError(f"Uploaded file URL format changed: {url}")
 
 
 def _sizeof_fmt(num):

--- a/tests/test_note_uploader.py
+++ b/tests/test_note_uploader.py
@@ -189,6 +189,12 @@ def test_upload_url_parser():
     assert _extract_file_id(good_url) == "5ef8c8e1-e388-4cd7-a2f3-535606b74136"
 
 
+def test_upload_url_parser_attachment():
+    attachment_url = "attachment:834f1ea4-b283-4c7f-acdb-bbff55026863:image.png"
+
+    assert _extract_file_id(attachment_url) == "834f1ea4-b283-4c7f-acdb-bbff55026863"
+
+
 def test_upload_url_parser_fail():
     bad_url = "https://google.com"
 


### PR DESCRIPTION
## Summary

- Notion now returns `attachment:UUID:filename` URLs instead of S3 URLs for uploaded files
- `_extract_file_id` only handled the old AWS S3 URL format, causing all notes with file attachments to fail with `ValueError: Uploaded file URL format changed`
- Added support for the new `attachment:` URL format while keeping backwards compatibility with S3 URLs

## Test plan

- [ ] New test `test_upload_url_parser_attachment` for the new URL format
- [ ] Existing S3 URL test still passes
- [ ] Existing failure test still passes
- [ ] Manually verified with real ENEX import against Notion API