### PR TITLE
fix: avoid getPublicPageData for spaceId during file upload

### DIFF
--- a/enex2notion/enex_uploader_block.py
+++ b/enex2notion/enex_uploader_block.py
@@ -35,7 +35,7 @@ def _upload_file(new_block, resource: EvernoteResource):
         "record": {
             "table": "block",
             "id": new_block.id,
-            "spaceId": new_block.space_info["spaceId"],
+            "spaceId": new_block._client.current_space.id,  # noqa: WPS437
         },
     }
 


### PR DESCRIPTION
## Summary

- `_upload_file` calls `new_block.space_info["spaceId"]` to get the space ID for file uploads
- `space_info` uses the `getPublicPageData` API endpoint, which returns 500 for private pages
- This causes all file/image uploads to fail with `HTTPError: 500 Server Error`
- Fix: use `client.current_space.id` instead, which is already available from initial authentication

## Test plan

- [ ] Existing tests pass
- [ ] Manually verified file uploads work with real ENEX import against Notion API