### PR TITLE
fix: handle non-string note attributes in note_hash computation

### DIFF
--- a/enex2notion/enex_types.py
+++ b/enex2notion/enex_types.py
@@ -47,7 +47,7 @@ class EvernoteNote(object):
 
             s1_hash = hashlib.sha1()
             for h in hashable:
-                s1_hash.update(h.encode("utf-8"))
+                s1_hash.update(str(h).encode("utf-8"))
             self._note_hash = s1_hash.hexdigest()  # noqa: WPS601
 
         return self._note_hash


### PR DESCRIPTION
## Summary

- When ENEX `note-attributes` contain nested XML elements, the parser returns dicts instead of strings
- `note_hash` calls `.encode("utf-8")` on each field, which crashes with `AttributeError: 'dict' object has no attribute 'encode'`
- Fix: coerce values to `str()` before encoding

Fixes #111

## Test plan

- [ ] Existing tests pass
- [ ] Reproduced the issue with ENEX files containing nested note-attributes