### PR TITLE
fix: use date columns for Evernote timestamps in DB mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,36 @@ The `--mode` option allows you to choose how to upload your notebooks: as databa
 
 Since `PAGE` mode does not benefit from having separate space for metadata, you can still preserve the note's original meta with the `--add-meta` option. It will attach a callout block with all meta info as a first block in each note [like this](https://imgur.com/a/lJTbprH).
 
+#### DB mode: pre-creating the database
+
+Due to Notion API changes, `DB` mode requires you to **pre-create the database** in Notion before running the import. Create a database under your root page with a title matching your ENEX filename (e.g., "My Notebook" for `My Notebook.enex`) and the following columns:
+
+| Column | Type | Description |
+|---|---|---|
+| Title | Title | Note title (default column) |
+| Evernote Tags | Multi-select | Tags from Evernote |
+| Evernote Web Clip URL | URL | Source URL (web clips only) |
+| Evernote Created | Date | Original creation date in Evernote |
+| Evernote Updated | Date | Original last edit date in Evernote |
+| Evernote Author | Text | Note author from Evernote |
+| Evernote Imported | Created time | When the note was imported (auto) |
+| Last Modified | Last edited time | Last Notion edit (auto) |
+
+Optionally, add these **formula columns** to unify Evernote and Notion timestamps:
+
+- **Real Created**: `if(empty(prop("Evernote Created")), prop("Evernote Imported"), prop("Evernote Created"))`
+- **Real Updated**: `if(empty(prop("Evernote Updated")), prop("Last Modified"), if(dateBetween(prop("Last Modified"), prop("Evernote Imported"), "seconds") > 120, prop("Last Modified"), prop("Evernote Updated")))`
+
+These formulas use the Evernote date when available, falling back to Notion timestamps for notes created directly in Notion. "Real Updated" switches to the Notion timestamp when a note is edited more than 2 minutes after import.
+
+A setup script is provided to create the database automatically using the official Notion API:
+
+```bash
+$ python scripts/create_notion_db.py --token <NOTION_API_TOKEN> --parent-page-id <PAGE_ID> --title "My Notebook"
+```
+
+See [scripts/create\_notion\_db.py](scripts/create_notion_db.py) for details. This requires a [Notion integration token](https://www.notion.so/my-integrations) (not `token_v2`).
+
 ### Web Clips
 
 Due to Notion's limitations Evernote web clips cannot be uploaded as-is. `enex2notion` provides two modes with the `--mode-webclips` option:

--- a/enex2notion/enex_uploader.py
+++ b/enex2notion/enex_uploader.py
@@ -45,7 +45,9 @@ def _upload_note(root, note: EvernoteNote, note_blocks, keep_failed):
     # Set proper name after everything is uploaded
     new_page.title_plaintext = note.title
 
-    _update_edit_time(new_page, note.updated)
+    # Only override edit time for PAGE mode; DB mode uses explicit date columns
+    if not isinstance(new_page, CollectionRowBlock):
+        _update_edit_time(new_page, note.updated)
 
 
 def _update_edit_time(page, date):
@@ -66,9 +68,11 @@ def _make_page(note, root):
     return (
         root.collection.add_row(
             title=tmp_name,
-            url=note.url,
-            tags=note.tags,
-            created=note.created,
+            evernote_web_clip_url=note.url,
+            evernote_tags=note.tags,
+            evernote_created=note.created,
+            evernote_updated=note.updated,
+            evernote_author=note.author,
         )
         if isinstance(root, CollectionViewPageBlock)
         else root.children.add_new(PageBlock, title_plaintext=tmp_name)

--- a/enex2notion/enex_uploader_modes.py
+++ b/enex2notion/enex_uploader_modes.py
@@ -44,8 +44,14 @@ def _get_notebook_database(root, title):
 
     schema = _make_notebook_db_schema()
 
-    # Show only Tags and Updated
-    properties_order = _properties_order(schema, "Tags", "Updated")
+    # Show key Evernote metadata columns
+    properties_order = _properties_order(
+        schema,
+        "Evernote Tags",
+        "Evernote Created",
+        "Evernote Updated",
+        "Evernote Author",
+    )
 
     cvb = root.children.add_new(CollectionViewPageBlock)
     cvb.collection = cvb._client.get_collection(  # noqa: WPS437
@@ -66,12 +72,15 @@ def _get_notebook_database(root, title):
 
 
 def _make_notebook_db_schema():
-    col_ids = rand_id_list(4, 4)
+    col_ids = rand_id_list(7, 4)
     return {
-        col_ids[0]: {"name": "Tags", "type": "multi_select", "options": []},
-        col_ids[1]: {"name": "URL", "type": "url"},
-        col_ids[2]: {"name": "Created", "type": "created_time"},
-        col_ids[3]: {"name": "Updated", "type": "last_edited_time"},
+        col_ids[0]: {"name": "Evernote Tags", "type": "multi_select", "options": []},
+        col_ids[1]: {"name": "Evernote Web Clip URL", "type": "url"},
+        col_ids[2]: {"name": "Evernote Created", "type": "date"},
+        col_ids[3]: {"name": "Evernote Updated", "type": "date"},
+        col_ids[4]: {"name": "Evernote Author", "type": "text"},
+        col_ids[5]: {"name": "Evernote Imported", "type": "created_time"},
+        col_ids[6]: {"name": "Last Modified", "type": "last_edited_time"},
         "title": {"name": "Title", "type": "title"},
     }
 
@@ -89,13 +98,17 @@ def _get_existing_notebook_database(root, title):
 
     # Make sure options has at least empty list, otherwise it will crash
     tag_col_id = next(
-        c_k
-        for c_k, c_v in child.collection.get("schema").items()
-        if c_v["name"] == "Tags"
+        (
+            c_k
+            for c_k, c_v in child.collection.get("schema").items()
+            if c_v["name"] in ("Tags", "Evernote Tags")
+        ),
+        None,
     )
 
-    if child.collection.get(f"schema.{tag_col_id}.options") is None:
-        child.collection.set(f"schema.{tag_col_id}.options", [])
+    if tag_col_id is not None:
+        if child.collection.get(f"schema.{tag_col_id}.options") is None:
+            child.collection.set(f"schema.{tag_col_id}.options", [])
 
     return child
 

--- a/scripts/create_notion_db.py
+++ b/scripts/create_notion_db.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Create a Notion database with the correct schema for enex2notion DB mode.
+
+Requires a Notion integration token (not token_v2).
+Create one at https://www.notion.so/my-integrations
+
+The integration must be connected to the parent page before running this script.
+
+Usage:
+    python scripts/create_notion_db.py \
+        --token <NOTION_API_TOKEN> \
+        --parent-page-id <PAGE_ID> \
+        --title "My Notebook"
+
+The --title should match your ENEX filename stem (e.g., "My Notebook" for
+"My Notebook.enex") so that enex2notion finds the database automatically.
+"""
+
+import argparse
+import json
+import sys
+
+import requests
+
+NOTION_API_VERSION = "2022-06-28"
+NOTION_API_BASE = "https://api.notion.com/v1"
+
+
+def create_database(token, parent_page_id, title):
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Notion-Version": NOTION_API_VERSION,
+        "Content-Type": "application/json",
+    }
+
+    body = {
+        "parent": {"type": "page_id", "page_id": parent_page_id},
+        "title": [{"type": "text", "text": {"content": title}}],
+        "properties": {
+            "Title": {"title": {}},
+            "Evernote Tags": {"multi_select": {"options": []}},
+            "Evernote Web Clip URL": {"url": {}},
+            "Evernote Created": {"date": {}},
+            "Evernote Updated": {"date": {}},
+            "Evernote Author": {"rich_text": {}},
+            "Evernote Imported": {"created_time": {}},
+            "Last Modified": {"last_edited_time": {}},
+        },
+    }
+
+    response = requests.post(
+        f"{NOTION_API_BASE}/databases", headers=headers, json=body
+    )
+
+    if response.status_code != 200:
+        print(f"Error creating database: {response.status_code}", file=sys.stderr)
+        print(response.text, file=sys.stderr)
+        sys.exit(1)
+
+    db = response.json()
+    db_id = db["id"]
+    print(f"Database '{title}' created successfully!")
+    print(f"Database ID: {db_id}")
+    print(f"URL: {db['url']}")
+
+    _add_formula_columns(headers, db_id)
+
+    return db_id
+
+
+def _add_formula_columns(headers, db_id):
+    formulas = {
+        "Real Created": {
+            "formula": {
+                "expression": (
+                    'if(empty(prop("Evernote Created")),'
+                    ' prop("Evernote Imported"),'
+                    ' prop("Evernote Created"))'
+                )
+            }
+        },
+        "Real Updated": {
+            "formula": {
+                "expression": (
+                    'if(empty(prop("Evernote Updated")),'
+                    " prop(\"Last Modified\"),"
+                    " if(dateBetween(prop(\"Last Modified\"),"
+                    ' prop("Evernote Imported"), "seconds") > 120,'
+                    " prop(\"Last Modified\"),"
+                    ' prop("Evernote Updated")))'
+                )
+            }
+        },
+    }
+
+    for name, config in formulas.items():
+        body = {"properties": {name: config}}
+        response = requests.patch(
+            f"{NOTION_API_BASE}/databases/{db_id}", headers=headers, json=body
+        )
+
+        if response.status_code != 200:
+            print(
+                f"Warning: failed to add '{name}' formula: {response.status_code}",
+                file=sys.stderr,
+            )
+            print(response.text, file=sys.stderr)
+        else:
+            print(f"Added formula column: {name}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create a Notion database for enex2notion DB mode import"
+    )
+    parser.add_argument(
+        "--token",
+        required=True,
+        help="Notion integration token (from notion.so/my-integrations)",
+    )
+    parser.add_argument(
+        "--parent-page-id",
+        required=True,
+        help="ID of the parent page (UUID, with or without dashes)",
+    )
+    parser.add_argument(
+        "--title",
+        required=True,
+        help="Database title (should match ENEX filename stem)",
+    )
+
+    args = parser.parse_args()
+    create_database(args.token, args.parent_page_id, args.title)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- DB mode previously used `created_time` and `last_edited_time` column types, which are auto-managed by Notion and get overwritten on any page edit
- New schema uses explicit `date` columns prefixed with "Evernote" for all imported metadata, preserving original timestamps reliably
- Adds `Evernote Author` field (previously only available via `--add-meta` callout)
- Keeps `Last Modified` as Notion-native for tracking actual edits in Notion

### New DB schema

| Column | Type | Description |
|---|---|---|
| Title | Title | Note title |
| Evernote Tags | Multi-select | Tags from Evernote |
| Evernote URL | URL | Source URL |
| Evernote Created | Date | Original Evernote creation date |
| Evernote Updated | Date | Original Evernote last edit date |
| Evernote Author | Text | Note author |
| Evernote Imported | Created time | Import timestamp (auto) |
| Last Modified | Last edited time | Last Notion edit (auto) |

### Setup script

Includes `scripts/create_notion_db.py` using the official Notion API to create the database with correct schema + optional formula columns (Real Created, Real Updated) that bridge imported and native Notion notes.

### Note on DB creation

Due to Notion internal API changes, programmatic database creation via `submitTransaction` no longer works. Users must pre-create the database either manually or using the provided script before running `enex2notion --mode DB`.

## Test plan

- [ ] Manually verified with real ENEX import — Evernote Created/Updated preserved correctly across page edits
- [ ] Existing databases with old column names ("Tags") still detected via backwards-compatible lookup
- [ ] Setup script tested against Notion API